### PR TITLE
Support for Batch Requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,41 +30,63 @@ function walk(data) {
 }
 
 function parse(xml, req, cb) {
+  var action = req.Action;
+  var responseKey = 'aws:' + action + 'Response';
+  var actionResultKey = 'aws:' + action + 'Result';
+
+  var validateResponse = function (data, json) {
+    if (!_.isArray(data['aws:ResponseStatus'])) {
+      throw new Error('XML response missing aws:ResponseStatus!\n' + json);
+    }
+    if (!_.isArray(data['aws:ResponseStatus'][0]['aws:StatusCode'])) {
+      throw new Error('XML response missing aws:StatusCode!\n' + json);
+    }
+    var statusCode = data['aws:ResponseStatus'][0]['aws:StatusCode'][0];
+    if (statusCode !== 'Success') {
+      throw new Error(statusCode + '\n' + json);
+    }
+    if (!_.isArray(data[actionResultKey]) || !data[actionResultKey].length) {
+      throw new Error('XML response missing ' + actionResultKey + '!\n' + json);
+    }
+    data = data[actionResultKey][0]['aws:Alexa'][0];
+    return walk(data);
+  };
+
   xml2js.parseString(xml, { ignoreAttrs: true, trim: true }, function (err, data) {
     if (err) { return cb(err); }
     // json string representation of response data (for debugging).
     var json = JSON.stringify(data, null, '  ');
     // We need to know the request action in order to know the tag names.
-    var action = req.Action;
     if (data.Response && _.isArray(data.Response.Errors)) {
       return cb(new Error(data.Response.Errors.reduce(function (memo, error) {
         if (memo) { memo += '\n'; }
         return memo += error.Error[0].Code[0] + ': ' + error.Error[0].Message[0];
       }, '')));
     }
-    var responseKey = 'aws:' + action + 'Response';
     if (!data[responseKey] || !_.isArray(data[responseKey]['aws:Response'])) {
       return cb(new Error('XML response missing aws:Response!\n' + json));
     }
     // Discard top level nodes. We are only interested on whats inside
     // `aws:Alexa`.
-    data = data[responseKey]['aws:Response'][0];
-    if (!_.isArray(data['aws:ResponseStatus'])) {
-      return cb(new Error('XML response missing aws:ResponseStatus!\n' + json));
+    data = data[responseKey]['aws:Response'];
+
+    // Batch requests support
+    var all = [];
+    try {
+      for (var i = 0, l = data.length; i < l; i++) {
+        // Require all responses to be valid
+        all.push(validateResponse(data[i], json));
+      }
+    } catch (e) {
+      return cb(e);
     }
-    if (!_.isArray(data['aws:ResponseStatus'][0]['aws:StatusCode'])) {
-      return cb(new Error('XML response missing aws:StatusCode!\n' + json));
+
+    // If it isn't a batch request, be backwards compatible (single response object)
+    if (all.length === 1) {
+      all = all[0];
     }
-    var statusCode = data['aws:ResponseStatus'][0]['aws:StatusCode'][0];
-    if (statusCode !== 'Success') {
-      return cb(new Error(statusCode + '\n' + json));
-    }
-    var actionResultKey = 'aws:' + action + 'Result';
-    if (!_.isArray(data[actionResultKey]) || !data[actionResultKey].length) {
-      return cb(new Error('XML response missing ' + actionResultKey + '!\n' + json));
-    }
-    data = data[actionResultKey][0]['aws:Alexa'][0];
-    cb(null, walk(data));
+
+    cb(null, all);
   });
 }
 

--- a/test.js
+++ b/test.js
@@ -153,3 +153,22 @@ exports.testSitesLinkingIn = function (t) {
   });
 };
 
+exports.testBatchRequestRank = function (t) {
+  var client = awis(options);
+  client({
+    Action: 'UrlInfo',
+    'UrlInfo.Shared.ResponseGroup': 'Rank',
+    'UrlInfo.1.Url': 'lupomontero.com',
+    'UrlInfo.2.Url': 'yahoo.com',
+    'UrlInfo.3.Url': 'weibo.com',
+    'UrlInfo.4.Url': 'github.com',
+    'UrlInfo.5.Url': 'monono.org'
+  }, function (err, res) {
+    t.ok(!err);
+    t.ok(res.length === 5);
+    res.forEach(function (response) {
+      t.ok(response.trafficData.dataUrl);
+    });
+    t.done();
+  });
+};


### PR DESCRIPTION
1. Moved a couple of variables to the top
2. Isolated the logic for validation of every aws:Response tag into a method in order to use it multiple times
3. Returns an object if the response had just one aws:Response tag, returns an array if it had multiple (batch request)
4. Sample test added, more tests should be added to validate when any site inside a batch request fails.