### PR TITLE
Add support for explicit attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ internals.walk = function (data) {
 };
 
 
-internals.parse = function (xml, req, cb) {
+internals.parse = function (xml, req, cb, explicitAttributes) {
 
   const action = req.Action;
   const responseKey = 'aws:' + action + 'Response';
@@ -76,9 +76,18 @@ internals.parse = function (xml, req, cb) {
     data = data[actionResultKey][0]['aws:Alexa'][0];
     return internals.walk(data);
   };
+  if (explicitAttributes) {
+    var ignoreAttrs = false;
+    var attrkey = 'attrs';
+    var charkey = 'element'
+  } else {
+    var ignoreAttrs = true;
+    var attrkey = '';
+    var charkey = ''
+  }
 
 
-  Xml2js.parseString(xml, { ignoreAttrs: true, trim: true }, (err, data) => {
+  Xml2js.parseString(xml, { ignoreAttrs: ignoreAttrs, attrkey: attrkey, trim: true, charkey: charkey }, (err, data) => {
 
     if (err) {
       return cb(err);
@@ -174,7 +183,7 @@ module.exports = function (options) {
         return cb(err);
       }
 
-      internals.parse(res.body, req, cb);
+      internals.parse(res.body, req, cb, options.explicitAttributes);
     });
   };
 };

--- a/test/awis.spec.js
+++ b/test/awis.spec.js
@@ -3,6 +3,7 @@
 
 const Assert = require('assert');
 const Awis = require('../');
+const _ = require('underscore');
 
 
 const options = {
@@ -228,6 +229,23 @@ describe('Awis', () => {
     });
   });
 
+
+  it('should return element attributes', (done) => {
+    _(options).extend({'explicitAttributes': true});
+    Awis(options)({
+      'Action': 'UrlInfo',
+      'Url': 'github.com',
+      'ResponseGroup': 'RankByCountry'
+    }, (err, res) => {
+
+      Assert.ok(!err);
+      Assert.ok(res.trafficData.dataUrl.element == 'github.com/');
+      res.trafficData.rankByCountry.country.forEach((country) => {
+        Assert.ok(country.hasOwnProperty('attrs'));
+      });
+      done();
+    });
+  });
 
 });
 


### PR DESCRIPTION
AWIS methods like RankByCoutry returninig the list of countries with
country-code as an attribute.
To consume such api we need access to these attributes.
To not break existing API we add an option for explicit attributes. Then
We can access attributes with .attrs and xml element with .element