### PR TITLE
Add support for session token

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ module.exports = function (options) {
 
   return function (req, cb) {
 
-    const region = options.region || 'us-west-1';
+    const region = (options && options.region) || process.env.AWS_REGION || 'us-west-1';
     const host = (req.Action === 'TopSites') ? `ats.${region}.amazonaws.com` : `awis.${region}.amazonaws.com`;
     const service = (req.Action === 'TopSites') ? 'AlexaTopSites' : 'awis';
     const pathname = '/api';
@@ -160,10 +160,24 @@ module.exports = function (options) {
       path
     };
 
-    const signRes = Aws4.sign(signOpts, {
-      accessKeyId: options.key,
-      secretAccessKey: options.secret
-    });
+    let signRes;
+
+    if (!options) {
+      signRes = Aws4.sign(signOpts);
+    }
+    else if (options.token) {
+      signRes = Aws4.sign(signOpts, {
+        accessKeyId: options.key,
+        secretAccessKey: options.secret,
+        sessionToken: options.token
+      });
+    }
+    else {
+      signRes = Aws4.sign(signOpts, {
+        accessKeyId: options.key,
+        secretAccessKey: options.secret
+      });
+    }
 
     Request(signRes, (err, res) => {
 


### PR DESCRIPTION
Improve/fix aws authentication. From aws4 documentation

```
Your AWS credentials (which can be found in your AWS console) can be specified in one of two ways:

As the second argument, like this:

  aws4.sign(requestOptions, {
    secretAccessKey: "<your-secret-access-key>",
    accessKeyId: "<your-access-key-id>",
    sessionToken: "<your-session-token>"
  })

From process.env, such as this:

  export AWS_SECRET_ACCESS_KEY="<your-secret-access-key>"
  export AWS_ACCESS_KEY_ID="<your-access-key-id>"
  export AWS_SESSION_TOKEN="<your-session-token>"

(will also use AWS_ACCESS_KEY and AWS_SECRET_KEY if available)

The sessionToken property and AWS_SESSION_TOKEN environment variable are optional for signing with IAM STS temporary credentials.
```